### PR TITLE
More GCC fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Lithium ICL Interpreter
 =======================
 
+[![Build Status](https://semaphoreci.com/api/v1/projects/87b6c85b-4e7d-47a4-8323-884a14484f36/496208/badge.svg)](https://semaphoreci.com/flyingjester/lithium)
+
 Copyright (C) 2015 Martin McDonough
 Version 0.01
 

--- a/lithium.cpp
+++ b/lithium.cpp
@@ -116,6 +116,7 @@ Value::Type MutualCast(Value::Type a, Value::Type b){
                 return Value::Floating;
         case Value::String: return Value::String;
     }
+    return Value::Null;
 }
 
 /* Numeric types are directly converted. Strings may convert -- see strtoll. Booleans fail. */
@@ -307,7 +308,7 @@ struct Error Context::AddAccessor(const std::string &name, Accessor a){
         const struct Error e = {false, std::string("Accessor ") + name + " already exists"};
         return e;
     }
-    else{
+    /* else */ {
         accessors.push_back(Property(name, a));
         const struct Error e = {true};
         return e;
@@ -330,7 +331,7 @@ struct Error Context::AddVariable(const std::string &name, struct Value &v, unsi
         const struct Error e = {false, std::string("Variable ") + name + " already exists"};
         return e;
     }
-    else{
+    /* else */ {
         variables.push_back(Variable(name, v, n));
         const struct Error e = {true};
         return e;
@@ -647,9 +648,9 @@ public:
     
     void CleanScope(Context *ctx){
         /* Clean up the stack. */
-        std::vector<Variable>::const_iterator i = ctx->variables.begin();
+        std::vector<Variable>::iterator i = ctx->variables.begin();
         while(i!=ctx->variables.end() && i->scope<scope) i++;
-        ctx->variables.erase(i.base(), ctx->variables.end());
+        ctx->variables.erase(i, ctx->variables.end());
     }
     
     static void SkipScope1(std::string::const_iterator &i, const std::string::const_iterator end){

--- a/lithium.cpp
+++ b/lithium.cpp
@@ -471,6 +471,10 @@ public:
         return true;
     }
     
+    static bool NotIsDecDigit(char c){
+        return !IsDecDigit(c);
+    }
+    
     struct Value Factor(Context *ctx, std::string::const_iterator &i, const std::string::const_iterator end){
         
         SkipWhitespace(i, end);
@@ -479,7 +483,7 @@ public:
         struct Value v = {Value::Null};
         
         /* If all of value is decimal digits and *i is a '.', then we should append the next identifier */
-        if((*i)=='.' && std::find_if_not(value.begin(), value.end(), IsDecDigit)==value.end() && !IsWhitespace(*(i+1))){
+        if((*i)=='.' && std::find_if(value.begin(), value.end(), NotIsDecDigit)==value.end() && !IsWhitespace(*(i+1))){
             value += '.';
             i++;
             value+=GetIdentifier(i, end);

--- a/lithium.cpp
+++ b/lithium.cpp
@@ -296,14 +296,14 @@ Context *Context::GetModule(const std::string &name){
     std::vector<struct Module>::const_iterator i = 
         std::find_if(modules.begin(), modules.end(), finder);
 
-    if(i==modules.cend()) return NULL;
+    if(i==modules.end()) return NULL;
     return i->ctx;
 }
         
 struct Error Context::AddAccessor(const std::string &name, Accessor a){
     struct name_finder<Property> finder(name);
     
-    if(std::find_if(accessors.begin(), accessors.end(), finder)!=accessors.cend()){
+    if(std::find_if(accessors.begin(), accessors.end(), finder)!=accessors.end()){
         const struct Error e = {false, std::string("Accessor ") + name + " already exists"};
         return e;
     }
@@ -320,13 +320,13 @@ Accessor Context::GetAccessor(const std::string &name){
     std::vector<Property>::const_iterator i = 
         std::find_if(accessors.begin(), accessors.end(), finder);
 
-    if(i==accessors.cend()) return NULL;
+    if(i==accessors.end()) return NULL;
     return i->accessor;
 }
 
 struct Error Context::AddVariable(const std::string &name, struct Value &v, unsigned n){
     struct name_finder<Variable> finder(name);
-    if(std::find_if(variables.begin(), variables.end(), finder)!=variables.cend()){
+    if(std::find_if(variables.begin(), variables.end(), finder)!=variables.end()){
         const struct Error e = {false, std::string("Variable ") + name + " already exists"};
         return e;
     }
@@ -649,7 +649,7 @@ public:
         /* Clean up the stack. */
         std::vector<Variable>::const_iterator i = ctx->variables.begin();
         while(i!=ctx->variables.end() && i->scope<scope) i++;
-        ctx->variables.erase(i, ctx->variables.end());
+        ctx->variables.erase(i.base(), ctx->variables.end());
     }
     
     static void SkipScope1(std::string::const_iterator &i, const std::string::const_iterator end){


### PR DESCRIPTION
It seems GCC has a weaker static analyzer than clang, and doesn't see that if every branch of a conditional ends in a return statement then there is no chance of not returning explicitly.
